### PR TITLE
feat: adding support for Glob patterns in root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.13.2](https://github.com/matteobertoldo/atomforce/compare/v0.12.5...v0.12.7) (2022-04-28)
+
+### Bug Fixes
+
+* added support for globs in root url
+
+
 ### [0.12.7](https://github.com/matteobertoldo/atomforce/compare/v0.12.5...v0.12.7) (2022-04-28)
 
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ In this structure in the WebDAV the `cartridges` folder will also be uploaded, t
 
 If the value of `root` is: `.` the full path will be considered, so the `cartridges` folder will also be uploaded in the WebDAV. If the path of your cartridges is on several levels: `cartridges/src` just indicate the complete path. Final slash is not required.
 
+Root option also supports [glob patterns](<https://en.wikipedia.org/wiki/Glob_(programming)>), If your project contains multiple top level folders:
+
+```
+sfcc-project
+| storefront-reference-architecture
+| | cartridges
+| | | app_storefront_base
+| | | bm_app_storefront_base
+|    ...
+| link_paypal
+| | cartridges
+| | | bm_paypal
+| | | bm_paypal_configuration
+      ...
+```
+
+you can use a wildcard to match a path pattern `**/cartridges` to pickup all cartridges.
+
 ### Cartridges List
 
 The `cartridges` option allows you to stay in watch on one or more cartridges and upload these accordingly in WebDAV. If this option is not defined in the `dw.json` file, the watcher filesystem will listen all event (add, change and delete) to all files and folders in the project root or path indicated in the `root` option, and all files and folders will be uploaded.

--- a/lib/dw/dwdav.js
+++ b/lib/dw/dwdav.js
@@ -2,6 +2,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import globrex from 'globrex';
 import request from 'request';
 
 class DWDAV {
@@ -74,12 +75,12 @@ class DWDAV {
     }
 
     const rootFolder = path.join(process.cwd(), root || this.config.root);
-    const uriPath = path.relative(rootFolder, filePath);
+    const remotePath = this.getRemoteRelativePath(filePath, rootFolder);
 
     return new Promise((resolve, reject) => {
       const req = request(
         Object.assign(this.getOpts(), {
-          uri: `/${uriPath}`,
+          uri: `${remotePath}`,
           method: 'PUT'
         }),
         (err, res, body) => {
@@ -154,6 +155,21 @@ class DWDAV {
         }
       );
     });
+  }
+
+  getRemoteRelativePath(path, root) {
+    // globrex returns a regex with an ending $ which needs to be removed to match the root directory
+    const rootPatternObj = globrex(root, { globstar: true });
+    const rootPatternStr = rootPatternObj.regex.source;
+
+    let rootPattern = '';
+    if (rootPatternStr.endsWith('$')) {
+      rootPattern = new RegExp(rootPatternStr.slice(0, -1));
+    } else {
+      rootPattern = new RegExp(rootPatternStr);
+    }
+
+    return path.replace(rootPattern, '');
   }
 }
 

--- a/lib/watcher/watcher-utils.js
+++ b/lib/watcher/watcher-utils.js
@@ -25,13 +25,13 @@ export default {
 
       for (let i = 0; i < cartridges.length; i++) {
         if (cartridges[i].length && cartridges[i].trim() !== '' && cartridges[i].trim() !== '.') {
-          arr.push(`${this.remoteroot(props)}/${cartridges[i]}`);
+          arr.push(`${this.remoteroot(props)}/${cartridges[i]}/**`);
         }
       }
 
-      return arr.length > 0 ? arr : this.remoteroot(props);
+      return arr.length > 0 ? arr : `${this.remoteroot(props)}/**`;
     } else {
-      return this.remoteroot(props);
+      return `${this.remoteroot(props)}/**`;
     }
   },
   remoteroot(props) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atomforce",
   "main": "./lib/atomforce",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Unofficial Salesforce™ Commerce Cloud uploader & manager for Atom. Upload your files and cartridges on SFCC via WebDAV.",
   "keywords": [
     "salesforce-commerce-cloud",
@@ -53,6 +53,7 @@
     "etch": "^0.14.1",
     "file-url": "^3.0.0",
     "filesize": "^8.0.7",
+    "globrex": "^0.1.2",
     "multimatch": "^4.0.0",
     "request": "^2.88.2",
     "walk": "^2.3.14",


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Adding support for glob patterns in the root attribute. 

### Any other comments?
The watcher works natively with globs so it was an easy fix to just add `**` to the end of the watch paths. Getting the remote path was a bit more tricky, `path.relative()` doesn't support glob so I used a glob to regex package to get regex and manually removed the end of string `$` part to match and replace base paths. It doesn't seem ideal but it does work.

### Checklist

Check all those that are applicable and complete. Put an `x` between the brackets (without spaces).

-   [x] Merged with latest `master` branch
-   [ ] Travis CI passes (Linux support)
-   [ ] Added new test (if necessary) to [spec](https://github.com/matteobertoldo/atomforce/tree/master/spec) directory
